### PR TITLE
feat: Add Raycaster class and example

### DIFF
--- a/projects/find-waffle/src/example/raycaster/index.html
+++ b/projects/find-waffle/src/example/raycaster/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>Keyboard Example</title>
+    <title>Raycaster Example</title>
 </html>
 <body>
     <script type="module" src="./main.ts"></script>

--- a/projects/find-waffle/src/example/raycaster/index.html
+++ b/projects/find-waffle/src/example/raycaster/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Keyboard Example</title>
+</html>
+<body>
+    <script type="module" src="./main.ts"></script>
+</body>

--- a/projects/find-waffle/src/example/raycaster/main.ts
+++ b/projects/find-waffle/src/example/raycaster/main.ts
@@ -57,7 +57,7 @@ function animate() {
 animate();
 
 /* Raycaster Settings */
-const raycaster = new Raycaster(camera, scene);
+const raycaster = new Raycaster(camera, scene, renderer);
 
 // 마우스가 오브젝트 위에 있을 때 색상 변경 예제
 const mouseMoveCallback: EventCallback = (intersects: THREE.Intersection[]) => {
@@ -121,5 +121,3 @@ raycaster.registerCallback('mousemove', mouseMoveCallbackForDrag);
 raycaster.registerCallback('click', clickCallback);
 raycaster.registerCallback('mousedown', mouseDownCallback);
 raycaster.registerCallback('mouseup', mouseUpCallback);
-
-raycaster.dispose();

--- a/projects/find-waffle/src/example/raycaster/main.ts
+++ b/projects/find-waffle/src/example/raycaster/main.ts
@@ -59,6 +59,9 @@ animate();
 /* Raycaster Settings */
 const raycaster = new Raycaster(camera, scene, renderer);
 const targetObjects: THREE.Object3D[] = [cube1, cube2, cube3];
+let dragging = false;
+let selectedObject: THREE.Object3D | null = null;
+let offset = new THREE.Vector3();
 
 // 마우스가 오브젝트 위에 있을 때 색상 변경 예제
 const mouseMoveCallback: EventCallback = (intersects: THREE.Intersection[]) => {
@@ -90,31 +93,27 @@ const clickCallback: EventCallback = (intersects: THREE.Intersection[]) => {
 const mouseMoveCallbackForDrag: EventCallback = (
   intersects: THREE.Intersection[],
 ) => {
-  if (raycaster.dragging && raycaster.selectedObject) {
+  if (dragging && selectedObject) {
     if (intersects.length > 0) {
       const intersect = intersects[0];
-      const newPosition = new THREE.Vector3()
-        .copy(intersect.point)
-        .add(raycaster.offset);
-      newPosition.z = raycaster.selectedObject.position.z; // z좌표 고정하고 x, y축으로만 drag -> customizing이 필요할 것
-      raycaster.selectedObject.position.copy(newPosition);
+      const newPosition = new THREE.Vector3().copy(intersect.point).add(offset);
+      newPosition.z = selectedObject.position.z; // z좌표 고정하고 x, y축으로만 drag -> customizing이 필요할 것
+      selectedObject.position.copy(newPosition);
     }
   }
 };
 
 const mouseDownCallback: EventCallback = (intersects: THREE.Intersection[]) => {
   if (intersects.length > 0) {
-    raycaster.dragging = true;
-    raycaster.selectedObject = intersects[0].object;
-    raycaster.offset
-      .copy(raycaster.selectedObject.position)
-      .sub(intersects[0].point);
+    dragging = true;
+    selectedObject = intersects[0].object;
+    offset.copy(selectedObject.position).sub(intersects[0].point);
   }
 };
 
 const mouseUpCallback: EventCallback = () => {
-  raycaster.dragging = false;
-  raycaster.selectedObject = null;
+  dragging = false;
+  selectedObject = null;
 };
 
 raycaster.registerCallback('mousemove', mouseMoveCallback, targetObjects);

--- a/projects/find-waffle/src/example/raycaster/main.ts
+++ b/projects/find-waffle/src/example/raycaster/main.ts
@@ -63,12 +63,21 @@ const mouseMoveCallback: EventCallback = (
   event: MouseEvent,
   intersects: THREE.Intersection[],
 ) => {
-  if (intersects.length > 0) {
-    intersects[0].object.material.color.set('#ff0000');
+  if (raycaster.dragging && raycaster.selectedObject) {
+    if (intersects.length > 0) {
+      const intersect = intersects[0];
+      raycaster.selectedObject.position
+        .copy(intersect.point)
+        .add(raycaster.offset);
+    }
   } else {
-    cube1.material.color.set(0x00ff00);
-    cube2.material.color.set(0x00ff00);
-    cube3.material.color.set(0x00ff00);
+    if (intersects.length > 0) {
+      intersects[0].object.material.color.set('#ff0000');
+    } else {
+      cube1.material.color.set(0x00ff00);
+      cube2.material.color.set(0x00ff00);
+      cube3.material.color.set(0x00ff00);
+    }
   }
 };
 
@@ -81,8 +90,30 @@ const clickCallback: EventCallback = (
   }
 };
 
+const mouseDownCallback: EventCallback = (
+  event: MouseEvent,
+  intersects: THREE.Intersection[],
+) => {
+  if (intersects.length > 0) {
+    raycaster.dragging = true;
+    raycaster.selectedObject = intersects[0].object;
+    raycaster.offset
+      .copy(raycaster.selectedObject.position)
+      .sub(intersects[0].point);
+  }
+};
+
+const mouseUpCallback: EventCallback = () => {
+  raycaster.dragging = false;
+  raycaster.selectedObject = null;
+};
+
 raycaster.setMouseMoveHandler(mouseMoveCallback);
 raycaster.setClickHandler(clickCallback);
+raycaster.setMouseDownHandler(mouseDownCallback);
+raycaster.setMouseUpHandler(mouseUpCallback);
 
 window.addEventListener('mousemove', (event) => raycaster.onMouseMove(event));
 window.addEventListener('click', (event) => raycaster.onClick(event));
+window.addEventListener('mousedown', (event) => raycaster.onMouseDown(event));
+window.addEventListener('mouseup', (event) => raycaster.onMouseUp(event));

--- a/projects/find-waffle/src/example/raycaster/main.ts
+++ b/projects/find-waffle/src/example/raycaster/main.ts
@@ -63,7 +63,7 @@ animate();
 const raycaster = new ListenableRaycaster(camera, scene, renderer);
 const targetObjects: THREE.Object3D[] = [cube1, cube2, cube3];
 let dragging = false;
-let selectedObject: THREE.Object3D | null = null;
+let selectedObject: THREE.Object3D | null = raycaster.selectedObject;
 let offset = new THREE.Vector3();
 
 // 마우스가 오브젝트 위에 있을 때 색상 변경 예제
@@ -86,9 +86,13 @@ const mouseMoveCallback: EventCallback = (intersects: THREE.Intersection[]) => {
   }
 };
 
-const clickCallback: EventCallback = (intersects: THREE.Intersection[]) => {
+const clickCallback: EventCallback = (
+  intersects: THREE.Intersection[],
+  mouseCoords?: THREE.Vector2,
+) => {
   if (intersects.length > 0) {
     console.log('Clicked', intersects[0].object);
+    mouseCoords && console.log(mouseCoords);
   }
 };
 

--- a/projects/find-waffle/src/example/raycaster/main.ts
+++ b/projects/find-waffle/src/example/raycaster/main.ts
@@ -71,17 +71,17 @@ const mouseMoveCallback: EventCallback = (intersects: THREE.Intersection[]) => {
   if (intersects.length > 0) {
     const intersectedObject = intersects[0].object;
 
-    if (raycaster.selectedObject !== intersectedObject) {
-      if (raycaster.selectedObject) {
-        raycaster.selectedObject.material.color.set('#00ff00');
+    if (selectedObject !== intersectedObject) {
+      if (selectedObject) {
+        selectedObject.material.color.set('#00ff00');
       }
-      raycaster.selectedObject = intersectedObject;
-      raycaster.selectedObject.material.color.set('#ff0000');
+      selectedObject = intersectedObject;
+      selectedObject.material.color.set('#ff0000');
     }
   } else {
-    if (raycaster.selectedObject) {
-      raycaster.selectedObject.material.color.set('#00ff00');
-      raycaster.selectedObject = null;
+    if (selectedObject) {
+      selectedObject.material.color.set('#00ff00');
+      selectedObject = null;
     }
   }
 };

--- a/projects/find-waffle/src/example/raycaster/main.ts
+++ b/projects/find-waffle/src/example/raycaster/main.ts
@@ -121,3 +121,5 @@ raycaster.registerCallback('mousemove', mouseMoveCallbackForDrag);
 raycaster.registerCallback('click', clickCallback);
 raycaster.registerCallback('mousedown', mouseDownCallback);
 raycaster.registerCallback('mouseup', mouseUpCallback);
+
+raycaster.dispose();

--- a/projects/find-waffle/src/example/raycaster/main.ts
+++ b/projects/find-waffle/src/example/raycaster/main.ts
@@ -113,8 +113,7 @@ const mouseMoveCallbackForDrag: EventCallback = (
 const mouseDownCallback: EventCallback = (intersects: THREE.Intersection[]) => {
   if (intersects.length > 0) {
     dragging = true;
-    selectedObject = intersects[0].object;
-    offset.copy(selectedObject.position).sub(intersects[0].point);
+    offset.copy(selectedObject!.position).sub(intersects[0].point);
   }
 };
 

--- a/projects/find-waffle/src/example/raycaster/main.ts
+++ b/projects/find-waffle/src/example/raycaster/main.ts
@@ -1,6 +1,9 @@
 import * as THREE from 'three';
 
-import { EventCallback, Raycaster } from '../../libs/raycaster/Raycaster.ts';
+import {
+  EventCallback,
+  ListenableRaycaster,
+} from '../../libs/raycaster/Raycaster.ts';
 
 /* Scene Settings */
 const canvas = document.createElement('canvas');
@@ -57,7 +60,7 @@ function animate() {
 animate();
 
 /* Raycaster Settings */
-const raycaster = new Raycaster(camera, scene, renderer);
+const raycaster = new ListenableRaycaster(camera, scene, renderer);
 const targetObjects: THREE.Object3D[] = [cube1, cube2, cube3];
 let dragging = false;
 let selectedObject: THREE.Object3D | null = null;

--- a/projects/find-waffle/src/example/raycaster/main.ts
+++ b/projects/find-waffle/src/example/raycaster/main.ts
@@ -58,6 +58,7 @@ animate();
 
 /* Raycaster Settings */
 const raycaster = new Raycaster(camera, scene, renderer);
+const targetObjects: THREE.Object3D[] = [cube1, cube2, cube3];
 
 // 마우스가 오브젝트 위에 있을 때 색상 변경 예제
 const mouseMoveCallback: EventCallback = (intersects: THREE.Intersection[]) => {
@@ -116,8 +117,12 @@ const mouseUpCallback: EventCallback = () => {
   raycaster.selectedObject = null;
 };
 
-raycaster.registerCallback('mousemove', mouseMoveCallback);
-raycaster.registerCallback('mousemove', mouseMoveCallbackForDrag);
-raycaster.registerCallback('click', clickCallback);
-raycaster.registerCallback('mousedown', mouseDownCallback);
-raycaster.registerCallback('mouseup', mouseUpCallback);
+raycaster.registerCallback('mousemove', mouseMoveCallback, targetObjects);
+raycaster.registerCallback(
+  'mousemove',
+  mouseMoveCallbackForDrag,
+  targetObjects,
+);
+raycaster.registerCallback('click', clickCallback, targetObjects);
+raycaster.registerCallback('mousedown', mouseDownCallback, targetObjects);
+raycaster.registerCallback('mouseup', mouseUpCallback, targetObjects);

--- a/projects/find-waffle/src/example/raycaster/main.ts
+++ b/projects/find-waffle/src/example/raycaster/main.ts
@@ -1,0 +1,88 @@
+import * as THREE from 'three';
+
+import { EventCallback, Raycaster } from '../../libs/raycaster/Raycaster.ts';
+
+/* Scene Settings */
+const canvas = document.createElement('canvas');
+canvas.width = window.innerWidth;
+canvas.height = window.innerHeight;
+canvas.style.position = 'absolute';
+canvas.style.top = '0';
+canvas.style.left = '0';
+canvas.style.margin = '0';
+canvas.style.padding = '0';
+document.body.appendChild(canvas);
+
+const camera = new THREE.PerspectiveCamera(
+  75,
+  window.innerWidth / window.innerHeight,
+  0.1,
+  1000,
+);
+const scene = new THREE.Scene();
+const renderer = new THREE.WebGLRenderer({ canvas });
+renderer.setSize(window.innerWidth, window.innerHeight);
+
+const geometry = new THREE.BoxGeometry();
+const material1 = new THREE.MeshBasicMaterial({ color: '#00ff00' });
+const material2 = new THREE.MeshBasicMaterial({ color: '#00ff00' });
+const material3 = new THREE.MeshBasicMaterial({ color: '#00ff00' });
+const cube1 = new THREE.Mesh(geometry, material1);
+const cube2 = new THREE.Mesh(geometry, material2);
+const cube3 = new THREE.Mesh(geometry, material3);
+cube1.position.x = -3;
+cube2.position.x = 0;
+cube3.position.x = 3;
+scene.add(cube1);
+scene.add(cube2);
+scene.add(cube3);
+
+camera.position.z = 5;
+
+function animate() {
+  requestAnimationFrame(animate);
+
+  cube1.rotation.x += 0.01;
+  cube1.rotation.y += 0.01;
+
+  cube2.rotation.x += 0.01;
+  cube2.rotation.y += 0.01;
+
+  cube3.rotation.x += 0.01;
+  cube3.rotation.y += 0.01;
+
+  renderer.render(scene, camera);
+}
+
+animate();
+
+/* Raycaster Settings */
+const raycaster = new Raycaster(camera, scene);
+
+const mouseMoveCallback: EventCallback = (
+  event: MouseEvent,
+  intersects: THREE.Intersection[],
+) => {
+  if (intersects.length > 0) {
+    intersects[0].object.material.color.set('#ff0000');
+  } else {
+    cube1.material.color.set(0x00ff00);
+    cube2.material.color.set(0x00ff00);
+    cube3.material.color.set(0x00ff00);
+  }
+};
+
+const clickCallback: EventCallback = (
+  event: MouseEvent,
+  intersects: THREE.Intersection[],
+) => {
+  if (intersects.length > 0) {
+    console.log('Clicked', intersects[0].object);
+  }
+};
+
+raycaster.setMouseMoveHandler(mouseMoveCallback);
+raycaster.setClickHandler(clickCallback);
+
+window.addEventListener('mousemove', (event) => raycaster.onMouseMove(event));
+window.addEventListener('click', (event) => raycaster.onClick(event));

--- a/projects/find-waffle/src/libs/raycaster/Raycaster.ts
+++ b/projects/find-waffle/src/libs/raycaster/Raycaster.ts
@@ -10,13 +10,14 @@ export class Raycaster extends THREE.Raycaster {
   camera: THREE.Camera;
   scene: THREE.Scene;
   mouseCoords: MouseCoords = new THREE.Vector2();
+  dragging: boolean = false;
   selectedObject: THREE.Object3D | null = null;
   offset: THREE.Vector3 = new THREE.Vector3();
   onMouseMoveCallback?: EventCallback;
   onClickCallback?: EventCallback;
-  //   onDblClickCallback?: EventCallback;
-  //   onMouseLeaveCallback?: EventCallback;
-  //   onDragCallback?: EventCallback;
+  onMouseDownCallback?: EventCallback;
+  onMouseUpCallback?: EventCallback;
+  onDblClickCallback?: EventCallback;
 
   constructor(camera: THREE.Camera, scene: THREE.Scene) {
     super();
@@ -45,6 +46,18 @@ export class Raycaster extends THREE.Raycaster {
     this.onClickCallback = clickCallback;
   }
 
+  setMouseDownHandler(mouseDownCallback: EventCallback) {
+    this.onMouseDownCallback = mouseDownCallback;
+  }
+
+  setMouseUpHandler(mouseUpCallback: EventCallback) {
+    this.onMouseUpCallback = mouseUpCallback;
+  }
+
+  setDblClickHandler(dblClickCallback: EventCallback) {
+    this.onDblClickCallback = dblClickCallback;
+  }
+
   // 이벤트 핸들러 설정
   handleEvent(event: MouseEvent, callback?: EventCallback) {
     if (callback) {
@@ -59,5 +72,17 @@ export class Raycaster extends THREE.Raycaster {
 
   onClick(event: MouseEvent) {
     this.handleEvent(event, this.onClickCallback);
+  }
+
+  onMouseDown(event: MouseEvent) {
+    this.handleEvent(event, this.onMouseDownCallback);
+  }
+
+  onMouseUp(event: MouseEvent) {
+    this.handleEvent(event, this.onMouseUpCallback);
+  }
+
+  onDblClick(event: MouseEvent) {
+    this.handleEvent(event, this.onDblClickCallback);
   }
 }

--- a/projects/find-waffle/src/libs/raycaster/Raycaster.ts
+++ b/projects/find-waffle/src/libs/raycaster/Raycaster.ts
@@ -1,10 +1,14 @@
 import * as THREE from 'three';
 
 type MouseCoords = THREE.Vector2;
-export type EventCallback = (
-  event: MouseEvent,
-  intersects: THREE.Intersection[],
-) => void;
+export type EventCallback = (intersects: THREE.Intersection[]) => void;
+interface EventCallbacks {
+  mousemove?: EventCallback[];
+  click?: EventCallback[];
+  mousedown?: EventCallback[];
+  mouseup?: EventCallback[];
+  dblclick?: EventCallback[];
+}
 
 export class Raycaster extends THREE.Raycaster {
   camera: THREE.Camera;
@@ -13,76 +17,55 @@ export class Raycaster extends THREE.Raycaster {
   dragging: boolean = false;
   selectedObject: THREE.Object3D | null = null;
   offset: THREE.Vector3 = new THREE.Vector3();
-  onMouseMoveCallback?: EventCallback;
-  onClickCallback?: EventCallback;
-  onMouseDownCallback?: EventCallback;
-  onMouseUpCallback?: EventCallback;
-  onDblClickCallback?: EventCallback;
+  callbacks: EventCallbacks = {};
 
   constructor(camera: THREE.Camera, scene: THREE.Scene) {
     super();
     this.camera = camera;
     this.scene = scene;
+
+    window.addEventListener('mousemove', this.handleEvent('mousemove'));
+    window.addEventListener('click', this.handleEvent('click'));
+    window.addEventListener('mousedown', this.handleEvent('mousedown'));
+    window.addEventListener('mouseup', this.handleEvent('mouseup'));
+    window.addEventListener('dblclick', this.handleEvent('dblclick'));
   }
 
-  // 기본 동작: 마우스 좌표값 업데이트, 레이캐스팅 통해 교차점 찾기
-  updateMouseCoords(event: MouseEvent) {
+  // 공통 동작: 마우스 좌표값 업데이트, 레이캐스팅 통해 교차점 찾기
+  getIntersects(event: MouseEvent): THREE.Intersection[] {
     this.mouseCoords.x = (event.clientX / window.innerWidth) * 2 - 1;
     this.mouseCoords.y = -(event.clientY / window.innerHeight) * 2 + 1;
-  }
-
-  getIntersects(event: MouseEvent): THREE.Intersection[] {
-    this.updateMouseCoords(event);
     this.setFromCamera(this.mouseCoords, this.camera);
     return this.intersectObjects(this.scene.children);
   }
 
   // 이벤트 핸들러에 콜백 등록
-  setMouseMoveHandler(mouseMoveCallback: EventCallback) {
-    this.onMouseMoveCallback = mouseMoveCallback;
-  }
-
-  setClickHandler(clickCallback: EventCallback) {
-    this.onClickCallback = clickCallback;
-  }
-
-  setMouseDownHandler(mouseDownCallback: EventCallback) {
-    this.onMouseDownCallback = mouseDownCallback;
-  }
-
-  setMouseUpHandler(mouseUpCallback: EventCallback) {
-    this.onMouseUpCallback = mouseUpCallback;
-  }
-
-  setDblClickHandler(dblClickCallback: EventCallback) {
-    this.onDblClickCallback = dblClickCallback;
+  registerCallback(eventType: keyof EventCallbacks, callback: EventCallback) {
+    if (!this.callbacks[eventType]) {
+      this.callbacks[eventType] = [];
+    }
+    this.callbacks[eventType]!.push(callback);
   }
 
   // 이벤트 핸들러 설정
-  handleEvent(event: MouseEvent, callback?: EventCallback) {
-    if (callback) {
+  handleEvent(eventType: keyof EventCallbacks) {
+    return (event: MouseEvent) => {
+      const callbacksForEvent = this.callbacks[eventType];
       const intersects = this.getIntersects(event);
-      callback(event, intersects);
-    }
+      if (callbacksForEvent) {
+        for (const callback of callbacksForEvent) {
+          callback(intersects);
+        }
+      }
+    };
   }
 
-  onMouseMove(event: MouseEvent) {
-    this.handleEvent(event, this.onMouseMoveCallback);
-  }
-
-  onClick(event: MouseEvent) {
-    this.handleEvent(event, this.onClickCallback);
-  }
-
-  onMouseDown(event: MouseEvent) {
-    this.handleEvent(event, this.onMouseDownCallback);
-  }
-
-  onMouseUp(event: MouseEvent) {
-    this.handleEvent(event, this.onMouseUpCallback);
-  }
-
-  onDblClick(event: MouseEvent) {
-    this.handleEvent(event, this.onDblClickCallback);
+  // raycaster.dispose() 호출 시 이벤트 리스너 제거
+  dispose() {
+    window.removeEventListener('mousemove', this.handleEvent('mousemove'));
+    window.removeEventListener('click', this.handleEvent('click'));
+    window.removeEventListener('mousedown', this.handleEvent('mousedown'));
+    window.removeEventListener('mouseup', this.handleEvent('mouseup'));
+    window.removeEventListener('dblclick', this.handleEvent('dblclick'));
   }
 }

--- a/projects/find-waffle/src/libs/raycaster/Raycaster.ts
+++ b/projects/find-waffle/src/libs/raycaster/Raycaster.ts
@@ -8,7 +8,7 @@ type EventCallbackMap = Map<
 >;
 export type EventCallback = (intersects: THREE.Intersection[]) => void;
 
-export class Raycaster extends THREE.Raycaster {
+export class ListenableRaycaster extends THREE.Raycaster {
   camera: THREE.Camera;
   scene: THREE.Scene;
   renderer: THREE.WebGLRenderer;

--- a/projects/find-waffle/src/libs/raycaster/Raycaster.ts
+++ b/projects/find-waffle/src/libs/raycaster/Raycaster.ts
@@ -36,11 +36,11 @@ export class ListenableRaycaster extends THREE.Raycaster {
       ['dblclick', []],
     ]);
 
-    this.eventListeners.mousemove = this.handleEvent('mousemove');
-    this.eventListeners.click = this.handleEvent('click');
-    this.eventListeners.mousedown = this.handleEvent('mousedown');
-    this.eventListeners.mouseup = this.handleEvent('mouseup');
-    this.eventListeners.dblclick = this.handleEvent('dblclick');
+    this.eventListeners.mousemove = this.createEventHandler('mousemove');
+    this.eventListeners.click = this.createEventHandler('click');
+    this.eventListeners.mousedown = this.createEventHandler('mousedown');
+    this.eventListeners.mouseup = this.createEventHandler('mouseup');
+    this.eventListeners.dblclick = this.createEventHandler('dblclick');
 
     window.addEventListener('mousemove', this.eventListeners.mousemove);
     window.addEventListener('click', this.eventListeners.click);
@@ -74,7 +74,7 @@ export class ListenableRaycaster extends THREE.Raycaster {
   }
 
   // 이벤트 핸들러 설정
-  private handleEvent(eventType: EventType) {
+  private createEventHandler(eventType: EventType) {
     return (event: MouseEvent) => {
       const callbackEntries = this.eventCallbackMap.get(eventType);
       if (callbackEntries) {

--- a/projects/find-waffle/src/libs/raycaster/Raycaster.ts
+++ b/projects/find-waffle/src/libs/raycaster/Raycaster.ts
@@ -13,6 +13,7 @@ interface EventCallbacks {
 export class Raycaster extends THREE.Raycaster {
   camera: THREE.Camera;
   scene: THREE.Scene;
+  renderer: THREE.WebGLRenderer;
   mouseCoords: MouseCoords = new THREE.Vector2();
   dragging: boolean = false;
   selectedObject: THREE.Object3D | null = null;
@@ -22,10 +23,15 @@ export class Raycaster extends THREE.Raycaster {
     [key in keyof EventCallbacks]?: (event: MouseEvent) => void;
   } = {};
 
-  constructor(camera: THREE.Camera, scene: THREE.Scene) {
+  constructor(
+    camera: THREE.Camera,
+    scene: THREE.Scene,
+    renderer: THREE.WebGLRenderer,
+  ) {
     super();
     this.camera = camera;
     this.scene = scene;
+    this.renderer = renderer;
 
     this.eventListeners.mousemove = this.handleEvent('mousemove');
     this.eventListeners.click = this.handleEvent('click');
@@ -42,8 +48,11 @@ export class Raycaster extends THREE.Raycaster {
 
   // 공통 동작: 마우스 좌표값 업데이트, 레이캐스팅 통해 교차점 찾기
   getIntersects(event: MouseEvent): THREE.Intersection[] {
-    this.mouseCoords.x = (event.clientX / window.innerWidth) * 2 - 1;
-    this.mouseCoords.y = -(event.clientY / window.innerHeight) * 2 + 1;
+    const canvas = this.renderer.domElement;
+    const rect = canvas.getBoundingClientRect();
+
+    this.mouseCoords.x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
+    this.mouseCoords.y = -((event.clientY - rect.top) / rect.height) * 2 + 1;
     this.setFromCamera(this.mouseCoords, this.camera);
     return this.intersectObjects(this.scene.children);
   }

--- a/projects/find-waffle/src/libs/raycaster/Raycaster.ts
+++ b/projects/find-waffle/src/libs/raycaster/Raycaster.ts
@@ -1,0 +1,63 @@
+import * as THREE from 'three';
+
+type MouseCoords = THREE.Vector2;
+export type EventCallback = (
+  event: MouseEvent,
+  intersects: THREE.Intersection[],
+) => void;
+
+export class Raycaster extends THREE.Raycaster {
+  camera: THREE.Camera;
+  scene: THREE.Scene;
+  mouseCoords: MouseCoords = new THREE.Vector2();
+  selectedObject: THREE.Object3D | null = null;
+  offset: THREE.Vector3 = new THREE.Vector3();
+  onMouseMoveCallback?: EventCallback;
+  onClickCallback?: EventCallback;
+  //   onDblClickCallback?: EventCallback;
+  //   onMouseLeaveCallback?: EventCallback;
+  //   onDragCallback?: EventCallback;
+
+  constructor(camera: THREE.Camera, scene: THREE.Scene) {
+    super();
+    this.camera = camera;
+    this.scene = scene;
+  }
+
+  // 기본 동작: 마우스 좌표값 업데이트, 레이캐스팅 통해 교차점 찾기
+  updateMouseCoords(event: MouseEvent) {
+    this.mouseCoords.x = (event.clientX / window.innerWidth) * 2 - 1;
+    this.mouseCoords.y = -(event.clientY / window.innerHeight) * 2 + 1;
+  }
+
+  getIntersects(event: MouseEvent): THREE.Intersection[] {
+    this.updateMouseCoords(event);
+    this.setFromCamera(this.mouseCoords, this.camera);
+    return this.intersectObjects(this.scene.children);
+  }
+
+  // 이벤트 핸들러에 콜백 등록
+  setMouseMoveHandler(mouseMoveCallback: EventCallback) {
+    this.onMouseMoveCallback = mouseMoveCallback;
+  }
+
+  setClickHandler(clickCallback: EventCallback) {
+    this.onClickCallback = clickCallback;
+  }
+
+  // 이벤트 핸들러 설정
+  handleEvent(event: MouseEvent, callback?: EventCallback) {
+    if (callback) {
+      const intersects = this.getIntersects(event);
+      callback(event, intersects);
+    }
+  }
+
+  onMouseMove(event: MouseEvent) {
+    this.handleEvent(event, this.onMouseMoveCallback);
+  }
+
+  onClick(event: MouseEvent) {
+    this.handleEvent(event, this.onClickCallback);
+  }
+}

--- a/projects/find-waffle/src/libs/raycaster/Raycaster.ts
+++ b/projects/find-waffle/src/libs/raycaster/Raycaster.ts
@@ -18,17 +18,26 @@ export class Raycaster extends THREE.Raycaster {
   selectedObject: THREE.Object3D | null = null;
   offset: THREE.Vector3 = new THREE.Vector3();
   callbacks: EventCallbacks = {};
+  eventListeners: {
+    [key in keyof EventCallbacks]?: (event: MouseEvent) => void;
+  } = {};
 
   constructor(camera: THREE.Camera, scene: THREE.Scene) {
     super();
     this.camera = camera;
     this.scene = scene;
 
-    window.addEventListener('mousemove', this.handleEvent('mousemove'));
-    window.addEventListener('click', this.handleEvent('click'));
-    window.addEventListener('mousedown', this.handleEvent('mousedown'));
-    window.addEventListener('mouseup', this.handleEvent('mouseup'));
-    window.addEventListener('dblclick', this.handleEvent('dblclick'));
+    this.eventListeners.mousemove = this.handleEvent('mousemove');
+    this.eventListeners.click = this.handleEvent('click');
+    this.eventListeners.mousedown = this.handleEvent('mousedown');
+    this.eventListeners.mouseup = this.handleEvent('mouseup');
+    this.eventListeners.dblclick = this.handleEvent('dblclick');
+
+    window.addEventListener('mousemove', this.eventListeners.mousemove);
+    window.addEventListener('click', this.eventListeners.click);
+    window.addEventListener('mousedown', this.eventListeners.mousedown);
+    window.addEventListener('mouseup', this.eventListeners.mouseup);
+    window.addEventListener('dblclick', this.eventListeners.dblclick);
   }
 
   // 공통 동작: 마우스 좌표값 업데이트, 레이캐스팅 통해 교차점 찾기
@@ -62,10 +71,21 @@ export class Raycaster extends THREE.Raycaster {
 
   // raycaster.dispose() 호출 시 이벤트 리스너 제거
   dispose() {
-    window.removeEventListener('mousemove', this.handleEvent('mousemove'));
-    window.removeEventListener('click', this.handleEvent('click'));
-    window.removeEventListener('mousedown', this.handleEvent('mousedown'));
-    window.removeEventListener('mouseup', this.handleEvent('mouseup'));
-    window.removeEventListener('dblclick', this.handleEvent('dblclick'));
+    this.callbacks = {};
+    if (this.eventListeners.mousemove) {
+      window.removeEventListener('mousemove', this.eventListeners.mousemove);
+    }
+    if (this.eventListeners.click) {
+      window.removeEventListener('click', this.eventListeners.click);
+    }
+    if (this.eventListeners.mousedown) {
+      window.removeEventListener('mousedown', this.eventListeners.mousedown);
+    }
+    if (this.eventListeners.mouseup) {
+      window.removeEventListener('mouseup', this.eventListeners.mouseup);
+    }
+    if (this.eventListeners.dblclick) {
+      window.removeEventListener('dblclick', this.eventListeners.dblclick);
+    }
   }
 }

--- a/projects/find-waffle/src/libs/raycaster/Raycaster.ts
+++ b/projects/find-waffle/src/libs/raycaster/Raycaster.ts
@@ -13,11 +13,8 @@ export class Raycaster extends THREE.Raycaster {
   scene: THREE.Scene;
   renderer: THREE.WebGLRenderer;
   mouseCoords: MouseCoords = new THREE.Vector2();
-  dragging: boolean = false;
-  selectedObject: THREE.Object3D | null = null;
-  offset: THREE.Vector3 = new THREE.Vector3();
-  eventCallbackMap: EventCallbackMap = new Map();
-  eventListeners: {
+  private eventCallbackMap: EventCallbackMap = new Map();
+  private eventListeners: {
     [key in EventType]?: (event: MouseEvent) => void;
   } = {};
 
@@ -53,7 +50,7 @@ export class Raycaster extends THREE.Raycaster {
   }
 
   // 공통 동작: 마우스 좌표값 업데이트, 레이캐스팅 통해 교차점 찾기
-  getIntersects(
+  private getIntersects(
     event: MouseEvent,
     targetObjects: THREE.Object3D[],
   ): THREE.Intersection[] {
@@ -77,7 +74,7 @@ export class Raycaster extends THREE.Raycaster {
   }
 
   // 이벤트 핸들러 설정
-  handleEvent(eventType: EventType) {
+  private handleEvent(eventType: EventType) {
     return (event: MouseEvent) => {
       const callbackEntries = this.eventCallbackMap.get(eventType);
       if (callbackEntries) {


### PR DESCRIPTION
PR이 늦어져 죄송합니다... 범용 클래스 만들어보는 게 처음이라 시간이 좀 걸렸습니다ㅠㅠㅠ

@minkyu97 PR 참고하여 같은 방식으로 테스트 해보실 수 있게 만들어 두었습니다.
```
1. `yarn find-waffle dev` 실행
2. http://localhost:5173/src/example/raycaster/index.html 접속
```
`main.ts`에서 확인할 수 있듯이, `intersects`만을 파라미터로 받는 함수를 선언하고, `registerCallback`을 통해 이벤트 핸들러에 등록할 수 있도록 설계해 보았습니다. 마우스 좌표값과 `intersects`를 알아내는 작업은 모든 마우스 이벤트에서 공통으로 일어나므로 클래스 내부에서 `getIntersects`를 통해 처리됩니다.

고민거리
1. 엄밀히 말하면 `main.ts`에서 정의하는 함수가 이벤트리스너의 콜백 함수가 아닌데, `EventCallback`이라는 이름을 쓰고 있어서 요 부분이 좀 걸리는데... 좋은 네이밍 있으면 추천 부탁드립니다
2. 그리고 drag 동작의 경우, 저희가 조작하는 게 DOM element는 아니기 때문에 drag event를 직접 쓸 수는 없다고 생각했고, `mousemove`, `mouseup`, `mousedown`을 이용하여 구현했는데요. 이 과정에서 `offset`이나 `dragging`과 같은 프로퍼티를 들고 있는 것도 지저분하고, 복수의 이벤트를 동시에 써야 된다는 점이 좀 신경쓰였습니다... 그래서 클래스에 그냥 심을까 생각했는데, 그럼 drag를 커스터마이징할 때 기존의 `intersects`만 받는 식으로 처리하기도 어려울 것 같아 통일성을 해치는 거 같기도 하여... 일단 지저분하게 두었는데 좋은 방법 있을까요??