### PR TITLE
feat: 공통 라이브러리, 유틸 추가

### DIFF
--- a/projects/find-waffle/package.json
+++ b/projects/find-waffle/package.json
@@ -10,8 +10,11 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "cannon-es": "^0.20.0",
+    "es-toolkit": "^1.8.0",
     "lil-gui": "^0.19.2",
-    "three": "^0.165.0"
+    "three": "^0.165.0",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@types/three": "^0.165.0",

--- a/projects/find-waffle/src/utils/image.ts
+++ b/projects/find-waffle/src/utils/image.ts
@@ -1,0 +1,74 @@
+/**
+ * 주어진 URL로부터 이미지를 로드합니다.
+ *
+ * @param url 이미지 URL
+ * @returns 이미지 비트맵 Promise
+ */
+export async function loadImage(url: string): Promise<ImageBitmap> {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Failed to load image: ${url}`);
+  }
+  const blob = await response.blob();
+  return createImageBitmap(blob);
+}
+
+type ColorSource = CanvasFillStrokeStyles['fillStyle'];
+
+export function createSolidColorImage(
+  color: ColorSource,
+  width: number,
+  height: number,
+): ImageBitmap {
+  const canvas = new OffscreenCanvas(width, height);
+  const ctx = canvas.getContext('2d')!;
+  ctx.fillStyle = color;
+  ctx.fillRect(0, 0, width, height);
+  return canvas.transferToImageBitmap();
+}
+
+type CompsiteImageOptions = {
+  // https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/globalCompositeOperation
+  compositeOperation?: GlobalCompositeOperation;
+  // true일 경우 overlay의 크기를 base의 크기로 맞춥니다.
+  fill?: boolean;
+};
+
+/**
+ * 2개의 이미지를 합성합니다.
+ * 합성된 이미지의 크기는 base의 크기 또는 overlay의 크기(base가 색상일 경우)와 같습니다.
+ *
+ * @param base 배경 이미지 또는 색상
+ * @param overlay 덧씌울 이미지
+ * @return 합성된 이미지
+ */
+export function compositeImage(
+  base: HTMLCanvasElement | ImageBitmap | ColorSource,
+  overlay: ImageBitmap,
+  {
+    compositeOperation = 'source-over',
+    fill = false,
+  }: CompsiteImageOptions = {},
+): ImageBitmap {
+  if (
+    typeof base === 'string' ||
+    base instanceof CanvasGradient ||
+    base instanceof CanvasPattern
+  ) {
+    base = createSolidColorImage(base, overlay.width, overlay.height);
+  }
+  const canvas = new OffscreenCanvas(base.width, base.height);
+  const ctx = canvas.getContext('2d')!;
+  ctx.drawImage(base, 0, 0);
+  ctx.globalCompositeOperation = compositeOperation;
+  if (fill) {
+    ctx.drawImage(overlay, 0, 0, base.width, base.height);
+  } else {
+    ctx.drawImage(
+      overlay,
+      (base.width - overlay.width) / 2,
+      (base.height - overlay.height) / 2,
+    );
+  }
+  return canvas.transferToImageBitmap();
+}

--- a/projects/find-waffle/src/utils/image.ts
+++ b/projects/find-waffle/src/utils/image.ts
@@ -2,7 +2,7 @@
  * 주어진 URL로부터 이미지를 로드합니다.
  *
  * @param url 이미지 URL
- * @returns 이미지 비트맵 Promise
+ * @returns 로딩된 이미지 프로미스
  */
 export async function loadImage(url: string): Promise<ImageBitmap> {
   const response = await fetch(url);
@@ -15,6 +15,13 @@ export async function loadImage(url: string): Promise<ImageBitmap> {
 
 type ColorSource = CanvasFillStrokeStyles['fillStyle'];
 
+/**
+ * 주어진 색상으로 채워진 이미지를 생성합니다.
+ * @param color 색상
+ * @param width 이미지 너비
+ * @param height 이미지 높이
+ * @returns 생성된 이미지
+ */
 export function createSolidColorImage(
   color: ColorSource,
   width: number,

--- a/projects/find-waffle/src/utils/index.ts
+++ b/projects/find-waffle/src/utils/index.ts
@@ -1,0 +1,3 @@
+export * from './image';
+export * from './three';
+export * from './url';

--- a/projects/find-waffle/src/utils/three.ts
+++ b/projects/find-waffle/src/utils/three.ts
@@ -1,0 +1,27 @@
+import * as THREE from 'three';
+
+/**
+ * 주어진 너비와 높이에 맞게 캔버스를 리사이즈하고 카메라의 비율을 조정합니다.
+ *
+ * @param renderer
+ * @param camera
+ * @param width
+ * @param height
+ */
+export function resize(
+  renderer: THREE.WebGLRenderer,
+  camera: THREE.Camera,
+  width: number,
+  height: number,
+): void {
+  renderer.setSize(width, height);
+  const aspect = width / height;
+  if (camera instanceof THREE.PerspectiveCamera) {
+    camera.aspect = aspect;
+    camera.updateProjectionMatrix();
+  } else if (camera instanceof THREE.OrthographicCamera) {
+    camera.left = camera.bottom * aspect;
+    camera.right = camera.top * aspect;
+    camera.updateProjectionMatrix();
+  }
+}

--- a/projects/find-waffle/src/utils/url.ts
+++ b/projects/find-waffle/src/utils/url.ts
@@ -1,0 +1,9 @@
+/**
+ * 주어진 상대 경로를 vite의 base 옵션에 근거해 절대 경로로 변환합니다.
+ *
+ * @param path 상대 경로
+ * @returns 절대 경로
+ */
+export function url(path: string): string {
+  return new URL(path, import.meta.url).href;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2756,6 +2756,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cannon-es@npm:^0.20.0":
+  version: 0.20.0
+  resolution: "cannon-es@npm:0.20.0"
+  checksum: 80f3904049d969d81fec76927fc4af88bb137616f63937918acec4c5759ff5129c321f8925ddf7efed0e5c833309d1520bcf4072a6217b55687cfa5fe229c58c
+  languageName: node
+  linkType: hard
+
 "chalk@npm:^2.4.2":
   version: 2.4.2
   resolution: "chalk@npm:2.4.2"
@@ -3190,6 +3197,13 @@ __metadata:
     is-date-object: "npm:^1.0.1"
     is-symbol: "npm:^1.0.2"
   checksum: 74aeeefe2714cf99bb40cab7ce3012d74e1e2c1bd60d0a913b467b269edde6e176ca644b5ba03a5b865fb044a29bca05671cd445c85ca2cdc2de155d7fc8fe9b
+  languageName: node
+  linkType: hard
+
+"es-toolkit@npm:^1.8.0":
+  version: 1.8.0
+  resolution: "es-toolkit@npm:1.8.0"
+  checksum: df668b2b979409b623012a2985d67a8d0bd7050f89350ee32093b7feb494029c812420e5e70b8c68e0cbe37657aadff25b1e049b6699bcd3bdcc019050752834
   languageName: node
   linkType: hard
 
@@ -3725,11 +3739,14 @@ __metadata:
     "@types/three": "npm:^0.165.0"
     "@typescript-eslint/eslint-plugin": "npm:^6.10.0"
     "@typescript-eslint/parser": "npm:^6.10.0"
+    cannon-es: "npm:^0.20.0"
+    es-toolkit: "npm:^1.8.0"
     eslint: "npm:^8.53.0"
     lil-gui: "npm:^0.19.2"
     three: "npm:^0.165.0"
     typescript: "npm:^5.2.2"
     vite: "npm:^5.0.0"
+    zod: "npm:^3.23.8"
   languageName: unknown
   linkType: soft
 
@@ -6623,6 +6640,13 @@ __metadata:
   version: 0.1.0
   resolution: "yocto-queue@npm:0.1.0"
   checksum: f77b3d8d00310def622123df93d4ee654fc6a0096182af8bd60679ddcdfb3474c56c6c7190817c84a2785648cdee9d721c0154eb45698c62176c322fb46fc700
+  languageName: node
+  linkType: hard
+
+"zod@npm:^3.23.8":
+  version: 3.23.8
+  resolution: "zod@npm:3.23.8"
+  checksum: 846fd73e1af0def79c19d510ea9e4a795544a67d5b34b7e1c4d0425bf6bfd1c719446d94cdfa1721c1987d891321d61f779e8236fde517dc0e524aa851a6eff1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# 공통 라이브러리 추가
* [zod](https://zod.dev/) - Typescript 친화적인 json 스키마 밸리데이터 라이브러리
* [es-toolkit](https://es-toolkit.slash.page/ko/) - 토스에서 개발한 경량 유틸 라이브러리
* [cannon-es](https://pmndrs.github.io/cannon-es/) - 경량 3D 물리엔진 cannon 의 유지보수 포크
* gsap

# 공통 유틸 추가
어떻게 나눠야할지 잘 모르겠는데 일단

* 이미지 처리 관련 → image.ts
* THREE 임포트가 필요한 경우 → three.ts
* url 관련 → url.ts

이렇게 나눠봤는데 더 좋은 방법 있으면 제안해주세요.
그리고 혹시 다른 유틸 추가한 거 있으면 여기다 직접 커밋하셔도 좋습니다. 물론 따로 PR 올려도 좋고요