### PR TITLE
[Three.js] 테두리 생성 유틸 추가

### DIFF
--- a/projects/find-waffle/src/utils/three.ts
+++ b/projects/find-waffle/src/utils/three.ts
@@ -25,3 +25,44 @@ export function resize(
     camera.updateProjectionMatrix();
   }
 }
+
+/**
+ * Material 에 테두리를 추가합니다.
+ * @param material 테두리를 추가할 Material
+ * @param color 테두리 색상
+ * @param width 테두리 두께
+ * @returns 테두리가 추가된 Material
+ */
+export function addBorderToMaterial(
+  material: THREE.Material,
+  color: THREE.ColorRepresentation,
+  width: number,
+): THREE.Material {
+  if (material.defines === undefined) material.defines = {};
+  material.defines.USE_UV = '';
+  material.onBeforeCompile = (shader) => {
+    shader.uniforms.size = { value: new THREE.Vector2(1, 1) };
+    shader.uniforms.borderWidth = { value: width };
+    shader.uniforms.borderColor = { value: new THREE.Color(color) };
+    shader.fragmentShader = `
+    uniform vec2 size;
+    uniform float borderWidth;
+    uniform vec3 borderColor;
+    ${shader.fragmentShader}
+  `.replace(
+      '#include <color_fragment>',
+      `
+  #include <color_fragment>
+  vec3 col = diffuseColor.rgb;
+  vec2 s = (size * 0.5) - borderWidth;
+  
+  vec2 ruv = abs((vUv - 0.5) * size);
+  vec2 fe = fwidth(ruv);
+  float e = min(fe.x, fe.y) * 0.5;
+  float border = smoothstep(s.x + e, s.x - e, ruv.x) * smoothstep(s.y + e, s.y - e, ruv.y);
+  diffuseColor.rgb = mix(borderColor, col, clamp(border, 0., 1.));   
+    `,
+    );
+  };
+  return material;
+}


### PR DESCRIPTION
Three JS 에서 물체에 테두리를 추가하는 것이 생각보다 까다롭습니다.
EdgesGeometry 와 LineBasicMaterial 을 활용하는 방법도 있지만, [공식 문서에도 나와있듯이](https://threejs.org/docs/?q=linebasic#api/en/materials/LineBasicMaterial.linewidth) 두께 조절이 가능하지 않습니다.

위의 한계점을 극복하기 위해 머터리얼의 프라그먼트 셰이더를 조작하여 테두리 두께와 색상을 자유롭게 지정할 수 있는 유틸을 추가합니다.

참고: https://discourse.threejs.org/t/how-to-make-a-2d-border-with-the-same-thickness-around-the-entire-perimeter/28487/6